### PR TITLE
Removed errant square bracket in routing example

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 // Use on your routes.
 Route::get('/', ['middleware' => 'shield'], function () {
     // Your protected page.
-}]);
+});
 
 // Use it within your controller constructor.
 $this->middleware('shield');


### PR DESCRIPTION
I removed an errant square bracket from the `Route::get` example.